### PR TITLE
Fixed bug that was causing crash of FATE regresion tests suite

### DIFF
--- a/ffmpeg-subtree/libavcodec/libxevd.c
+++ b/ffmpeg-subtree/libavcodec/libxevd.c
@@ -722,7 +722,6 @@ AVCodec ff_libxevd_decoder = {
     .priv_data_size   = sizeof(XevdContext),
     .priv_class       = &xevd_class,
     .defaults         = xevd_defaults,
-    .capabilities     = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS |
-    AV_CODEC_CAP_ENCODER_REORDERED_OPAQUE,
+    .capabilities     = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS | AV_CODEC_CAP_AVOID_PROBING,
     .wrapper_name     = "libxevd",
 };

--- a/ffmpeg-subtree/libavformat/evcdec.c
+++ b/ffmpeg-subtree/libavformat/evcdec.c
@@ -55,17 +55,19 @@ static int get_nalu_type(const uint8_t *bs, int bs_size)
     return nut - 1;
 }
 
-static int read_nal_unit_size(const uint8_t *bs, int bs_size)
+static size_t read_nal_unit_size(const unsigned char *bs, int bs_size)
 {
-    int nal_unit_size = 0;
+    size_t nal_unit_size = 0;
     memcpy(&nal_unit_size, bs, EVC_NAL_UNIT_LENGTH_BYTE);
+
     return nal_unit_size;
 }
 
 static int parse_nal_units(const AVProbeData *p, EVCParserContext *ev)
 {
-    int nalu_type, nalu_size;
-    unsigned char * bits = (unsigned char *)p->buf;
+    int nalu_type;
+    size_t nalu_size;
+    unsigned char* bits = (unsigned char *)p->buf;
     int bytes_to_read = p->buf_size;
     
     av_log(NULL, AV_LOG_DEBUG, "bytes_to_read: %d \n", bytes_to_read);
@@ -73,10 +75,11 @@ static int parse_nal_units(const AVProbeData *p, EVCParserContext *ev)
     while(bytes_to_read > EVC_NAL_UNIT_LENGTH_BYTE) {
     
         nalu_size = read_nal_unit_size(bits, p->buf_size);
+
         bits += EVC_NAL_UNIT_LENGTH_BYTE;
         bytes_to_read -= EVC_NAL_UNIT_LENGTH_BYTE;
 
-        av_log(NULL, AV_LOG_DEBUG, "nalu_size: %d \n", nalu_size);
+        av_log(NULL, AV_LOG_DEBUG, "nalu_size: %ld \n", nalu_size);
 
         if(bytes_to_read < nalu_size) break;
 


### PR DESCRIPTION
api-band-test was ending with segmentation fault after evc_probe function had been called