### PR TITLE
Reordered include header files

### DIFF
--- a/ffmpeg-subtree/libavcodec/evc_parser.c
+++ b/ffmpeg-subtree/libavcodec/evc_parser.c
@@ -22,9 +22,9 @@
 
 #include <stdint.h>
 
-#include "libavutil/common.h"
+#include <xevd.h>
 
-#include "xevd.h"
+#include "libavutil/common.h"
 
 #include "parser.h"
 #include "golomb.h"

--- a/ffmpeg-subtree/libavcodec/evc_parser.c
+++ b/ffmpeg-subtree/libavcodec/evc_parser.c
@@ -20,12 +20,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <stdint.h>
+
 #include "libavutil/common.h"
 
-#include "golomb.h"
-#include "parser.h"
 #include "xevd.h"
-#include <stdint.h>
+
+#include "parser.h"
+#include "golomb.h"
 
 #define EVC_NAL_HEADER_SIZE   2 /* byte */
 #define MAX_SPS_CNT  16 /* defined value in EVC standard */
@@ -61,7 +63,7 @@ typedef struct EVCParserContext {
     int got_slice;
 } EVCParserContext;
 
-static int get_nalu_type(const uint8_t *bs, int bs_size)
+static av_unused int get_nalu_type(const uint8_t *bs, int bs_size)
 {
     GetBitContext gb;
     int fzb, nut;

--- a/ffmpeg-subtree/libavcodec/libxevd.c
+++ b/ffmpeg-subtree/libavcodec/libxevd.c
@@ -28,14 +28,14 @@
 #include <float.h>
 #include <stdlib.h>
 
+#include <xevd.h>
+
 #include "libavutil/internal.h"
 #include "libavutil/common.h"
 #include "libavutil/opt.h"
 #include "libavutil/pixdesc.h"
 #include "libavutil/pixfmt.h"
 #include "libavutil/imgutils.h"
-
-#include <xevd.h>
 
 #include "avcodec.h"
 #include "internal.h"

--- a/ffmpeg-subtree/libavcodec/libxevd.c
+++ b/ffmpeg-subtree/libavcodec/libxevd.c
@@ -25,8 +25,6 @@
 #define XEVD_API_IMPORTS 1
 #endif
 
-#include <xevd.h>
-
 #include <float.h>
 #include <stdlib.h>
 
@@ -37,14 +35,15 @@
 #include "libavutil/pixfmt.h"
 #include "libavutil/imgutils.h"
 
-// #define USE_EXP_GOLOMB_STUFF
-#ifdef USE_EXP_GOLOMB_STUFF
-#include "golomb.h"
-#endif
+#include <xevd.h>
 
 #include "avcodec.h"
 #include "internal.h"
 #include "packet_internal.h"
+// #define USE_EXP_GOLOMB_STUFF
+#ifdef USE_EXP_GOLOMB_STUFF
+#include "golomb.h"
+#endif
 
 #define UNUSED(x) (void)(x)
 

--- a/ffmpeg-subtree/libavcodec/libxeve.c
+++ b/ffmpeg-subtree/libavcodec/libxeve.c
@@ -28,14 +28,14 @@
 #include <float.h>
 #include <stdlib.h>
 
+#include <xeve.h>
+
 #include "libavutil/internal.h"
 #include "libavutil/common.h"
 #include "libavutil/opt.h"
 #include "libavutil/pixdesc.h"
 #include "libavutil/pixfmt.h"
 #include "libavutil/time.h"
-
-#include <xeve.h>
 
 #include "avcodec.h"
 #include "internal.h"

--- a/ffmpeg-subtree/libavcodec/libxeve.c
+++ b/ffmpeg-subtree/libavcodec/libxeve.c
@@ -25,8 +25,6 @@
 #define XEVE_API_IMPORTS 1
 #endif
 
-#include <xeve.h>
-
 #include <float.h>
 #include <stdlib.h>
 
@@ -36,6 +34,8 @@
 #include "libavutil/pixdesc.h"
 #include "libavutil/pixfmt.h"
 #include "libavutil/time.h"
+
+#include <xeve.h>
 
 #include "avcodec.h"
 #include "internal.h"

--- a/ffmpeg-subtree/libavformat/evcdec.c
+++ b/ffmpeg-subtree/libavformat/evcdec.c
@@ -20,11 +20,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <xevd.h>
+
 #include "libavcodec/get_bits.h"
 #include "libavcodec/golomb.h"
 #include "libavcodec/internal.h"
-
-#include "xevd.h"
 
 #include "rawdec.h"
 #include "avformat.h"

--- a/ffmpeg-subtree/libavformat/evcdec.c
+++ b/ffmpeg-subtree/libavformat/evcdec.c
@@ -22,10 +22,12 @@
 
 #include "libavcodec/get_bits.h"
 #include "libavcodec/golomb.h"
-#include "avformat.h"
-#include "rawdec.h"
 #include "libavcodec/internal.h"
+
 #include "xevd.h"
+
+#include "rawdec.h"
+#include "avformat.h"
 
 typedef struct EVCParserContext {
     int got_sps;


### PR DESCRIPTION
Include headers in the following order: Related header, C system
headers, C standard library headers, other libraries' headers, project's
headers.