### PR TITLE
Changes related to FFCodec structure initialization for both libxeve …

### DIFF
--- a/ffmpeg-subtree/libavcodec/libxevd.c
+++ b/ffmpeg-subtree/libavcodec/libxevd.c
@@ -416,4 +416,5 @@ const FFCodec ff_libxevd_decoder = {
     .p.priv_class       = &libxevd_class,
     .p.capabilities     = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_AVOID_PROBING | AV_CODEC_CAP_DR1,
     .p.wrapper_name     = "libxevd",
+    .caps_internal      = FF_CODEC_CAP_INIT_CLEANUP | FF_CODEC_CAP_NOT_INIT_THREADSAFE,
 };

--- a/ffmpeg-subtree/libavcodec/libxeve.c
+++ b/ffmpeg-subtree/libavcodec/libxeve.c
@@ -591,7 +591,8 @@ const FFCodec ff_libxeve_encoder = {
     .priv_data_size     = sizeof(XeveContext),
     .p.priv_class       = &libxeve_class,
     .defaults           = libxeve_defaults,
-    .p.capabilities     = FF_CODEC_CAP_INIT_CLEANUP | AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS | AV_CODEC_CAP_DR1,
+    .p.capabilities     = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_DR1,
     .p.wrapper_name     = "libxeve",
     .p.pix_fmts         = supported_pixel_formats,
+    .caps_internal      = FF_CODEC_CAP_INIT_CLEANUP | FF_CODEC_CAP_NOT_INIT_THREADSAFE,
 };


### PR DESCRIPTION
…and libxevd

Added FF_CODEC_CAP_NOT_INIT_THREADSAFE flags to FFCodec.caps_internal
since there is no public information confirming that libxeve and libxevd
libraries are thread safe

Moved FF_CODEC_CAP_INIT_CLEANUP internal flag to FFCodec.caps_internal