### PR TITLE
Added missing header decode.h to libxevd.c to avoid errors caused by …

### DIFF
--- a/ffmpeg-subtree/libavcodec/libxevd.c
+++ b/ffmpeg-subtree/libavcodec/libxevd.c
@@ -39,6 +39,7 @@
 #include "packet_internal.h"
 #include "codec_internal.h"
 #include "profiles.h"
+#include "decode.h"
 
 #define XEVD_PARAM_BAD_NAME -1
 #define XEVD_PARAM_BAD_VALUE -2


### PR DESCRIPTION
…implicit declaration of functons ff_set_dimensions and ff_get_buffer