### PR TITLE
Fixed error 'moov atom not found' that had appeared while converting …

### DIFF
--- a/ffmpeg-subtree/libavcodec/evc_parser.c
+++ b/ffmpeg-subtree/libavcodec/evc_parser.c
@@ -459,7 +459,6 @@ static int parse_nal_units(AVCodecParserContext *s, const uint8_t *bs,
     int bits_size = bs_size;
 
     avctx->codec_id = AV_CODEC_ID_EVC;
-    s->pict_type = AV_PICTURE_TYPE_NONE;
     s->picture_structure = AV_PICTURE_STRUCTURE_FRAME;
     s->key_frame = -1;
 

--- a/ffmpeg-subtree/libavformat/demux.c
+++ b/ffmpeg-subtree/libavformat/demux.c
@@ -119,6 +119,7 @@ static int set_codec_from_probe_data(AVFormatContext *s, AVStream *st,
         { "mp3",        AV_CODEC_ID_MP3,          AVMEDIA_TYPE_AUDIO    },
         { "mpegvideo",  AV_CODEC_ID_MPEG2VIDEO,   AVMEDIA_TYPE_VIDEO    },
         { "truehd",     AV_CODEC_ID_TRUEHD,       AVMEDIA_TYPE_AUDIO    },
+        { "evc",        AV_CODEC_ID_EVC,          AVMEDIA_TYPE_VIDEO    },
         { 0 }
     };
     int score;

--- a/ffmpeg-subtree/libavformat/mov.c
+++ b/ffmpeg-subtree/libavformat/mov.c
@@ -2500,6 +2500,7 @@ static int mov_finalize_stsd_codec(MOVContext *c, AVIOContext *pb,
     case AV_CODEC_ID_VP9:
         sti->need_parsing = AVSTREAM_PARSE_FULL;
         break;
+    case AV_CODEC_ID_EVC:
     case AV_CODEC_ID_AV1:
         /* field_order detection of H264 requires parsing */
     case AV_CODEC_ID_H264:


### PR DESCRIPTION
…mp4[evc,aac] stream to elementary evc stream