### PR TITLE
Hotfix in the EVC demultiplexer following introducing framerate param…

### DIFF
--- a/ffmpeg-subtree/libavformat/evcdec.c
+++ b/ffmpeg-subtree/libavformat/evcdec.c
@@ -172,7 +172,7 @@ static int evc_read_header(AVFormatContext *s)
     sti->need_parsing = AVSTREAM_PARSE_HEADERS;
 
     st->avg_frame_rate = c->framerate;
-    sti->avctx->framerate = c->framerate;
+    st->codecpar->framerate = c->framerate;
 
     // taken from rawvideo demuxers
     avpriv_set_pts_info(st, 64, 1, 1200000);


### PR DESCRIPTION
…eter to AVCodecParameters

Changes introduced in codec_par.(h,c) in commit a4a41a842b4410f75924f7c4ce3af1a365573e65 caused a problem with playing the primary EVC video stream. The result was an incorrect playback speed of the stream.